### PR TITLE
Add user defined functions for Tree creation and completion

### DIFF
--- a/action_server_bt/include/action_server_bt/action_server_bt.hpp
+++ b/action_server_bt/include/action_server_bt/action_server_bt.hpp
@@ -37,7 +37,7 @@ public:
   using GoalHandleActionTree = rclcpp_action::ServerGoalHandle<ActionTree>;
 
   typedef std::function<void(BT::Tree&)> OnTreeCreatedCallback;
-  typedef std::function<void(BT::NodeStatus&)> onTreeExecutionCompletedCallback;
+  typedef std::function<void(BT::NodeStatus&)> OnTreeExecutionCompletedCallback;
 
   /**
    * @brief Constructor for ActionServerBT.
@@ -47,7 +47,7 @@ public:
    * @param options rclcpp::NodeOptions to pass to node_ when initializing it.
    */
   explicit ActionServerBT(const rclcpp::NodeOptions& options, OnTreeCreatedCallback tree_created,
-                          onTreeExecutionCompletedCallback execution_complete);
+                          OnTreeExecutionCompletedCallback execution_complete);
 
   /**
    * @brief Gets the NodeBaseInterface of node_.
@@ -69,7 +69,7 @@ private:
 
   BT::BehaviorTreeFactory factory_;
   OnTreeCreatedCallback on_tree_created_;
-  onTreeExecutionCompletedCallback on_execution_complete_;
+  OnTreeExecutionCompletedCallback on_execution_complete_;
   std::shared_ptr<BT::Groot2Publisher> groot_publisher_;
 
   /**

--- a/action_server_bt/include/action_server_bt/action_server_bt.hpp
+++ b/action_server_bt/include/action_server_bt/action_server_bt.hpp
@@ -14,6 +14,7 @@
 #include <functional>
 #include <memory>
 #include <thread>
+#include <optional>
 
 #include "action_server_bt_msgs/action/action_tree.hpp"
 #include "action_server_bt_parameters.hpp"
@@ -79,10 +80,12 @@ protected:
   }
 
   // To be overridden by the user.
-  // Callback invoked after the tickOnce. Return false to stop the execution
-  virtual bool onLoopAfterTick(BT::NodeStatus status)
+  // Callback invoked after the tickOnce.
+  // If it returns something different than std::nullopt, the tree execution will
+  // be halted and the returned value will be the optional NodeStatus.
+  virtual std::optional<BT::NodeStatus> onLoopAfterTick(BT::NodeStatus status)
   {
-    return true;
+    return std::nullopt;
   }
 
   // To be overridden by the user.

--- a/action_server_bt/include/action_server_bt/action_server_bt.hpp
+++ b/action_server_bt/include/action_server_bt/action_server_bt.hpp
@@ -71,6 +71,8 @@ public:
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr getNodeBaseInterface();
 
 private:
+  const UserCallbacks user_cbs_;
+
   rclcpp::Node::SharedPtr node_;
   rclcpp_action::Server<ActionTree>::SharedPtr action_server_;
   std::thread action_thread_;
@@ -81,7 +83,6 @@ private:
   action_server_bt::Params params_;
 
   BT::BehaviorTreeFactory factory_;
-  UserCallbacks user_cbs_;
   std::shared_ptr<BT::Groot2Publisher> groot_publisher_;
 
   /**

--- a/action_server_bt/include/action_server_bt/action_server_bt.hpp
+++ b/action_server_bt/include/action_server_bt/action_server_bt.hpp
@@ -45,9 +45,51 @@ public:
    * starts an Action Server that takes requests to execute BehaviorTrees.
    *
    * @param options rclcpp::NodeOptions to pass to node_ when initializing it.
+   * @param tree_created user defined function that is called after the tree is created.
+   * @param execution_complete user defined function that is called after the tree has finished.
    */
   explicit ActionServerBT(const rclcpp::NodeOptions& options, OnTreeCreatedCallback tree_created,
                           OnTreeExecutionCompletedCallback execution_complete);
+
+  /**
+   * @brief Constructor for ActionServerBT.
+   * @details This initializes a ParameterListener to read configurable options from the user and
+   * starts an Action Server that takes requests to execute BehaviorTrees with no user defined callbacks.
+   *
+   * @param options rclcpp::NodeOptions to pass to node_ when initializing it.
+   */
+  explicit ActionServerBT(const rclcpp::NodeOptions& options)
+    : ActionServerBT(
+          options, [](BT::Tree&) {}, [](BT::NodeStatus&) {})
+  {
+  }
+
+  /**
+   * @brief Constructor for ActionServerBT.
+   * @details This initializes a ParameterListener to read configurable options from the user and
+   * starts an Action Server that takes requests to execute BehaviorTrees.
+   *
+   * @param options rclcpp::NodeOptions to pass to node_ when initializing it.
+   * @param tree_created user defined function that is called after the tree is created.
+   */
+  explicit ActionServerBT(const rclcpp::NodeOptions& options, OnTreeCreatedCallback tree_created)
+    : ActionServerBT(options, tree_created, [](BT::NodeStatus&) {})
+  {
+  }
+
+  /**
+   * @brief Constructor for ActionServerBT.
+   * @details This initializes a ParameterListener to read configurable options from the user and
+   * starts an Action Server that takes requests to execute BehaviorTrees.
+   *
+   * @param options rclcpp::NodeOptions to pass to node_ when initializing it.
+   * @param execution_complete user defined function that is called after the tree has finished.
+   */
+  explicit ActionServerBT(const rclcpp::NodeOptions& options, OnTreeExecutionCompletedCallback execution_complete)
+    : ActionServerBT(
+          options, [](BT::Tree&) {}, execution_complete)
+  {
+  }
 
   /**
    * @brief Gets the NodeBaseInterface of node_.

--- a/action_server_bt/include/action_server_bt/action_server_bt.hpp
+++ b/action_server_bt/include/action_server_bt/action_server_bt.hpp
@@ -36,6 +36,9 @@ public:
   using ActionTree = action_server_bt_msgs::action::ActionTree;
   using GoalHandleActionTree = rclcpp_action::ServerGoalHandle<ActionTree>;
 
+  typedef std::function<void(BT::Tree&)> OnTreeCreatedCallback;
+  typedef std::function<void(BT::NodeStatus&)> onTreeExecutionCompletedCallback;
+
   /**
    * @brief Constructor for ActionServerBT.
    * @details This initializes a ParameterListener to read configurable options from the user and
@@ -43,7 +46,8 @@ public:
    *
    * @param options rclcpp::NodeOptions to pass to node_ when initializing it.
    */
-  explicit ActionServerBT(const rclcpp::NodeOptions& options);
+  explicit ActionServerBT(const rclcpp::NodeOptions& options, OnTreeCreatedCallback tree_created,
+                          onTreeExecutionCompletedCallback execution_complete);
 
   /**
    * @brief Gets the NodeBaseInterface of node_.
@@ -64,6 +68,8 @@ private:
   action_server_bt::Params params_;
 
   BT::BehaviorTreeFactory factory_;
+  OnTreeCreatedCallback on_tree_created_;
+  onTreeExecutionCompletedCallback on_execution_complete_;
   std::shared_ptr<BT::Groot2Publisher> groot_publisher_;
 
   /**

--- a/action_server_bt/src/action_server_bt.cpp
+++ b/action_server_bt/src/action_server_bt.cpp
@@ -22,8 +22,7 @@ static const auto kLogger = rclcpp::get_logger("action_server_bt");
 namespace action_server_bt
 {
 ActionServerBT::ActionServerBT(const rclcpp::NodeOptions& options, const UserCallbacks& user_callbacks)
-  : node_{ std::make_shared<rclcpp::Node>("action_server_bt", options) }
-  , user_cbs_{user_callbacks}
+  : node_{ std::make_shared<rclcpp::Node>("action_server_bt", options) }, user_cbs_{ user_callbacks }
 {
   // parameter setup
   param_listener_ = std::make_shared<action_server_bt::ParamListener>(node_);

--- a/action_server_bt/src/action_server_bt.cpp
+++ b/action_server_bt/src/action_server_bt.cpp
@@ -23,10 +23,8 @@ namespace action_server_bt
 {
 ActionServerBT::ActionServerBT(const rclcpp::NodeOptions& options, const UserCallbacks& user_callbacks)
   : node_{ std::make_shared<rclcpp::Node>("action_server_bt", options) }
+  , user_cbs_{user_callbacks}
 {
-  // initialize user callbacks
-  user_cbs_ = user_callbacks;
-
   // parameter setup
   param_listener_ = std::make_shared<action_server_bt::ParamListener>(node_);
   params_ = param_listener_->get_params();

--- a/action_server_bt/src/action_server_bt.cpp
+++ b/action_server_bt/src/action_server_bt.cpp
@@ -22,7 +22,7 @@ static const auto kLogger = rclcpp::get_logger("action_server_bt");
 namespace action_server_bt
 {
 ActionServerBT::ActionServerBT(const rclcpp::NodeOptions& options, OnTreeCreatedCallback tree_created,
-                               onTreeExecutionCompletedCallback execution_complete)
+                               OnTreeExecutionCompletedCallback execution_complete)
   : node_{ std::make_shared<rclcpp::Node>("action_server_bt", options) }
 {
   // initialize user callbacks for tree creation and execution complete

--- a/action_server_bt/src/action_server_bt.cpp
+++ b/action_server_bt/src/action_server_bt.cpp
@@ -139,6 +139,9 @@ void ActionServerBT::execute(const std::shared_ptr<GoalHandleActionTree> goal_ha
   // call user defined execution complete function
   on_execution_complete_(status);
 
+  // set the node_status result to the action
+  action_result->node_status = convert_node_status(status);
+
   // return success or aborted for the action result
   if (status == BT::NodeStatus::SUCCESS)
   {

--- a/action_server_bt/src/action_server_bt.cpp
+++ b/action_server_bt/src/action_server_bt.cpp
@@ -124,6 +124,7 @@ void ActionServerBT::execute(const std::shared_ptr<GoalHandleActionTree> goal_ha
         RCLCPP_ERROR(kLogger, action_result->error_message.c_str());
         tree_->haltTree();
         goal_handle->canceled(action_result);
+        onTreeExecutionCompleted(status, true);
         return;
       }
 
@@ -156,7 +157,7 @@ void ActionServerBT::execute(const std::shared_ptr<GoalHandleActionTree> goal_ha
   }
 
   // call user defined execution complete function
-  onTreeExecutionCompleted(status, cancel_requested_);
+  onTreeExecutionCompleted(status, false);
 
   // set the node_status result to the action
   action_result->node_status = convert_node_status(status);

--- a/action_server_bt/src/action_server_bt_node.cpp
+++ b/action_server_bt/src/action_server_bt_node.cpp
@@ -18,7 +18,12 @@ int main(int argc, char* argv[])
   rclcpp::init(argc, argv);
 
   rclcpp::NodeOptions options;
-  auto node = std::make_shared<action_server_bt::ActionServerBT>(options);
+  // create a persistent logger and pass it into the function that will be called on Tree creation
+  std::shared_ptr<BT::StdCoutLogger> logger_cout;
+  auto on_tree_creation = [&logger_cout](BT::Tree& tree) { logger_cout = std::make_shared<BT::StdCoutLogger>(tree); };
+  // create an empty function for onTreeExecutionComplete
+  auto on_complete = [](BT::NodeStatus& status) {};
+  auto node = std::make_shared<action_server_bt::ActionServerBT>(options, on_tree_creation, on_complete);
 
   // TODO: This workaround is for a bug in MultiThreadedExecutor where it can deadlock when spinning without a timeout.
   // Deadlock is caused when Publishers or Subscribers are dynamically removed as the node is spinning.

--- a/action_server_bt/src/action_server_bt_node.cpp
+++ b/action_server_bt/src/action_server_bt_node.cpp
@@ -20,8 +20,9 @@ int main(int argc, char* argv[])
   rclcpp::NodeOptions options;
   // create a persistent logger and pass it into the function that will be called on Tree creation
   std::shared_ptr<BT::StdCoutLogger> logger_cout;
-  auto on_tree_creation = [&logger_cout](BT::Tree& tree) { logger_cout = std::make_shared<BT::StdCoutLogger>(tree); };
-  auto node = std::make_shared<action_server_bt::ActionServerBT>(options, on_tree_creation);
+  action_server_bt::UserCallbacks user_cb;
+  user_cb.on_create = [&logger_cout](BT::Tree& tree) { logger_cout = std::make_shared<BT::StdCoutLogger>(tree); };
+  auto node = std::make_shared<action_server_bt::ActionServerBT>(options, user_cb);
 
   // TODO: This workaround is for a bug in MultiThreadedExecutor where it can deadlock when spinning without a timeout.
   // Deadlock is caused when Publishers or Subscribers are dynamically removed as the node is spinning.

--- a/action_server_bt/src/action_server_bt_node.cpp
+++ b/action_server_bt/src/action_server_bt_node.cpp
@@ -13,23 +13,44 @@
 
 #include <action_server_bt/action_server_bt.hpp>
 
+// Example that shows how to customize ActionServerBT.
+// Here, we simply add an extra logger
+class MyActionServer : public action_server_bt::ActionServerBT
+{
+public:
+  MyActionServer(const rclcpp::NodeOptions& options) : ActionServerBT(options)
+  {
+  }
+
+  void onTreeCreated(BT::Tree& tree) override
+  {
+    logger_cout_ = std::make_shared<BT::StdCoutLogger>(tree);
+  }
+
+  void onTreeExecutionCompleted(BT::NodeStatus status, bool was_cancelled) override
+  {
+    // NOT really needed, even if logger_cout_ may contain a dangling pointer of the tree
+    // at this point
+    logger_cout_.reset();
+  }
+
+private:
+  std::shared_ptr<BT::StdCoutLogger> logger_cout_;
+};
+
 int main(int argc, char* argv[])
 {
   rclcpp::init(argc, argv);
 
   rclcpp::NodeOptions options;
-  // create a persistent logger and pass it into the function that will be called on Tree creation
-  std::shared_ptr<BT::StdCoutLogger> logger_cout;
-  action_server_bt::UserCallbacks user_cb;
-  user_cb.on_create = [&logger_cout](BT::Tree& tree) { logger_cout = std::make_shared<BT::StdCoutLogger>(tree); };
-  auto node = std::make_shared<action_server_bt::ActionServerBT>(options, user_cb);
+  auto action_server = std::make_shared<MyActionServer>(options);
 
   // TODO: This workaround is for a bug in MultiThreadedExecutor where it can deadlock when spinning without a timeout.
   // Deadlock is caused when Publishers or Subscribers are dynamically removed as the node is spinning.
   rclcpp::executors::MultiThreadedExecutor exec(rclcpp::ExecutorOptions(), 0, false, std::chrono::milliseconds(250));
-  exec.add_node(node->getNodeBaseInterface());
+  exec.add_node(action_server->nodeBaseInterface());
   exec.spin();
-  exec.remove_node(node->getNodeBaseInterface());
+  exec.remove_node(action_server->nodeBaseInterface());
 
   rclcpp::shutdown();
 }

--- a/action_server_bt/src/action_server_bt_node.cpp
+++ b/action_server_bt/src/action_server_bt_node.cpp
@@ -21,9 +21,7 @@ int main(int argc, char* argv[])
   // create a persistent logger and pass it into the function that will be called on Tree creation
   std::shared_ptr<BT::StdCoutLogger> logger_cout;
   auto on_tree_creation = [&logger_cout](BT::Tree& tree) { logger_cout = std::make_shared<BT::StdCoutLogger>(tree); };
-  // create an empty function for onTreeExecutionComplete
-  auto on_complete = [](BT::NodeStatus& status) {};
-  auto node = std::make_shared<action_server_bt::ActionServerBT>(options, on_tree_creation, on_complete);
+  auto node = std::make_shared<action_server_bt::ActionServerBT>(options, on_tree_creation);
 
   // TODO: This workaround is for a bug in MultiThreadedExecutor where it can deadlock when spinning without a timeout.
   // Deadlock is caused when Publishers or Subscribers are dynamically removed as the node is spinning.

--- a/action_server_bt/src/bt_utils.cpp
+++ b/action_server_bt/src/bt_utils.cpp
@@ -34,6 +34,8 @@ action_server_bt_msgs::msg::NodeStatus convert_node_status(BT::NodeStatus& statu
       action_status.status = action_server_bt_msgs::msg::NodeStatus::FAILURE;
     case BT::NodeStatus::IDLE:
       action_status.status = action_server_bt_msgs::msg::NodeStatus::IDLE;
+    case BT::NodeStatus::SKIPPED:
+      action_status.status = action_server_bt_msgs::msg::NodeStatus::SKIPPED;
   }
 
   return action_status;

--- a/action_server_bt_msgs/action/ActionTree.action
+++ b/action_server_bt_msgs/action/ActionTree.action
@@ -3,6 +3,7 @@ string target_tree
 ---
 # Result
 string error_message
+NodeStatus node_status
 ---
 # Feedback
 NodeStatus node_status

--- a/action_server_bt_msgs/msgs/NodeStatus.msg
+++ b/action_server_bt_msgs/msgs/NodeStatus.msg
@@ -3,5 +3,6 @@ uint8 IDLE = 0
 uint8 RUNNING = 1
 uint8 SUCCESS = 2
 uint8 FAILURE = 3
+uint8 SKIPPED = 4
 
 uint8 status


### PR DESCRIPTION
This PR address feedback from the discussion over in [BT.CPP](https://github.com/BehaviorTree/BehaviorTree.CPP/discussions/806) 

- Add user defined callbacks for `OnTreeCreation` and `OnTreeExecutionCompleted`
- Adds status `SKIPPED` to NodeStatus.msg
- Adds NodeStatus to Action result
- Switches to tree.sleep() to regulate tick rate